### PR TITLE
fix(readme): remove unnecessary `

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ $ sail up -d
 ```
 > Pode ser necessário **sudo**.
 
-> Caso seja mudado algo em `docker-compose.yml` é recomendado que use o comando `sail up -d --build`` para fazer a build dos novos containers e em seguida `sail up`.
+> Caso seja mudado algo em `docker-compose.yml` é recomendado que use o comando `sail up -d --build` para fazer a build dos novos containers e em seguida `sail up`.
 
 6. Precisamos entrar no nosso Docker e dar as permissões de escrita para as pastas de log e storage do Laravel:
 ```


### PR DESCRIPTION
Sem querer acabei colocando um " ` " a mais no Doc. na seção das instruções de instalação causando esse erro:

![image](https://user-images.githubusercontent.com/30880723/130368381-45ccdebc-4547-4c85-9413-b92a8b520f1b.png)

Bastou remover o caractere desnecessário para voltar a legibilidade normal.

![image](https://user-images.githubusercontent.com/30880723/130368435-2ea60b38-6435-4bcd-8ad1-d7bf7dd41d35.png)

Tá ai a correção, mal o vacilo.