### PR TITLE
chore(courses): change video duration to integer

### DIFF
--- a/LMS/Courses/Models/Course.php
+++ b/LMS/Courses/Models/Course.php
@@ -44,8 +44,19 @@ class Course extends Model implements HasMedia
     protected $appends = [
         'lessonsCount',
         'lessonsWatched',
-        'progress'
+        'progress',
+        'duration'
     ];
+
+    /*
+     * Get all lessons duration in seconds.
+     * Hint: use gmdate() to output
+     */
+    public function getDurationAttribute(): int
+    {
+        return $this->lessons()->sum('duration');
+    }
+
 
     public function getProgressAttribute() {
 

--- a/LMS/Lessons/Database/migrations/2021_08_05_204244_create_course_module_lessons_table.php
+++ b/LMS/Lessons/Database/migrations/2021_08_05_204244_create_course_module_lessons_table.php
@@ -21,7 +21,7 @@ class CreateCourseModuleLessonsTable extends Migration
             $table->string('title');
             $table->string('description');
             $table->text('content')->nullable();
-            $table->time('duration')->nullable();
+            $table->integer('duration')->nullable();
 
             $table->timestamps();
         });

--- a/LMS/Lessons/Models/Lesson.php
+++ b/LMS/Lessons/Models/Lesson.php
@@ -45,7 +45,7 @@ class Lesson extends Model implements HasMedia
 
     public function getDurationAttribute(): string
     {
-        return substr($this->attributes['duration'], 3, 6);
+        return substr(gmdate('H:i:s', $this->attributes['duration']), 3, 6);
     }
 
     public function type(): BelongsTo

--- a/LMS/Lessons/Repositories/LessonRepository.php
+++ b/LMS/Lessons/Repositories/LessonRepository.php
@@ -100,7 +100,7 @@ class LessonRepository
             $duration = FFProbe::create()
                 ->format($model->getFirstMediaPath())
                 ->get('duration');
-            $model->update(['duration' => gmdate('H:i:s', $duration)]);
+            $model->update(['duration' => $duration]);
         } catch (\Exception) {
             // TODO: implementar logger
         }


### PR DESCRIPTION
Acabei percebendo que estava fazendo uma tratativa desnecessária antes do tempo previsto. Tratar a duração da lição como "time" diretamente não deixa espaço para uma maior manipulação à longo prazo. 

Segue um fix pra resolver a situação. 