### PR TITLE
feat: dashboard domain with hero section

### DIFF
--- a/LMS/Courses/Http/Controllers/CoursesController.php
+++ b/LMS/Courses/Http/Controllers/CoursesController.php
@@ -41,6 +41,6 @@ class CoursesController extends Controller
     public function postEnrollment(Course $course): RedirectResponse
     {
         $this->repository->enroll($course);
-        return back();
+        return redirect(route('course-lesson-redirect', ['slug' => $course->slug]));
     }
 }

--- a/LMS/Courses/Models/Course.php
+++ b/LMS/Courses/Models/Course.php
@@ -58,7 +58,8 @@ class Course extends Model implements HasMedia
     }
 
 
-    public function getProgressAttribute() {
+    public function getProgressAttribute(): int|string
+    {
 
         return $this->lessonsWatched && $this->lessonsCount
             ?number_format(($this->lessonsWatched / $this->lessonsCount ?? 0) * 100,2)

--- a/LMS/Courses/Repositories/CourseRepository.php
+++ b/LMS/Courses/Repositories/CourseRepository.php
@@ -38,6 +38,9 @@ class CourseRepository
 
     public function enroll(Course $course)
     {
-        Auth::user()->enrollments()->attach($course, ['joined_at' => Carbon::now()]);
+        $alreadyEnrolled = Auth::user()->enrollments()->find($course);
+        if (!$alreadyEnrolled) {
+            Auth::user()->enrollments()->attach($course, ['joined_at' => Carbon::now()]);
+        }
     }
 }

--- a/LMS/Dashboard/Domain.php
+++ b/LMS/Dashboard/Domain.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LMS\Dashboard;
+
+use LMS\Core\Contracts\DomainInterface;
+use LMS\Dashboard\Providers\DashboardServiceProvider;
+
+class Domain extends DomainInterface
+{
+    public function registerProvider(): array
+    {
+        return [
+            DashboardServiceProvider::class
+        ];
+    }
+}

--- a/LMS/Dashboard/Http/Controllers/ViewController.php
+++ b/LMS/Dashboard/Http/Controllers/ViewController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LMS\Dashboard\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Contracts\View\View;
+use LMS\Dashboard\Repositories\DashboardRepository;
+
+class ViewController extends Controller
+{
+    private DashboardRepository $repository;
+
+    public function __construct(DashboardRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function viewDashboard(): View
+    {
+        $hero = $this->repository->getHeroCardInformation();
+        return view('dashboard::dashboard', compact('hero'));
+    }
+}

--- a/LMS/Dashboard/Providers/DashboardServiceProvider.php
+++ b/LMS/Dashboard/Providers/DashboardServiceProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LMS\Dashboard\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+use LMS\Dashboard\View\Components\DashboardHero;
+
+class DashboardServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->loadViewsFrom(__DIR__ . '/../Resources/views', 'dashboard');
+        Blade::component(DashboardHero::class, 'dashboard-hero');
+    }
+}

--- a/LMS/Dashboard/Repositories/DashboardRepository.php
+++ b/LMS/Dashboard/Repositories/DashboardRepository.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace LMS\Dashboard\Repositories;
+
+use Illuminate\Support\Facades\Auth;
+use LMS\Courses\Models\Course;
+
+class DashboardRepository
+{
+    public function getHeroCardInformation(): array
+    {
+        $hasAnyCourse = Auth::user()->enrollments()->count();
+        $hasAnyLessonWatched = Auth::user()->watched()->count();
+
+        if ($hasAnyCourse && $hasAnyLessonWatched) {
+            return [
+                'type' => 'lastSeen',
+                'course' => $this->getLastAccessedCourse()
+            ];
+        }
+
+        return [
+            'type' => 'mostRated',
+            'course' => $this->getMostRatedCourse()
+        ];
+    }
+
+    private function getLastAccessedCourse()
+    {
+        return Auth::user()
+            ->watched()
+            ->latest()
+            ->first()
+            ->module
+            ->course;
+    }
+
+    private function getMostRatedCourse()
+    {
+        return Course::first();
+    }
+}

--- a/LMS/Dashboard/Repositories/DashboardRepository.php
+++ b/LMS/Dashboard/Repositories/DashboardRepository.php
@@ -37,6 +37,14 @@ class DashboardRepository
 
     private function getMostRatedCourse()
     {
-        return Course::first();
+        $count = 0;
+        foreach (Course::where('paid', false)->get() as $course) {
+            $studentsCount = $course->students()->count();
+            if ($studentsCount > $count) {
+                $result = $course;
+                $count = $studentsCount;
+            }
+        }
+        return $result ?? Course::first();
     }
 }

--- a/LMS/Dashboard/Resources/scss/dashboard.scss
+++ b/LMS/Dashboard/Resources/scss/dashboard.scss
@@ -1,0 +1,66 @@
+.dashboard {
+    .card {
+        .hero-ribbon-wrapper {
+            width: 85px;
+            height: 88px;
+            overflow: hidden;
+            position: absolute;
+            top: -3px;
+            right: -3px;
+            z-index:1000;
+        }
+        .ribbon {
+            font-size: 10px;
+            color: #000;
+            text-transform: uppercase;
+            font-family: 'Montserrat Bold', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+            letter-spacing: .05em;
+            line-height: 15px;
+            text-align: center;
+            text-shadow: 0 -1px 0 rgba(0, 0, 0, .4);
+            -webkit-transform: rotate(45deg);
+            -moz-transform: rotate(45deg);
+            -ms-transform: rotate(45deg);
+            -o-transform: rotate(45deg);
+            transform: rotate(45deg);
+            position: relative;
+            padding: 11px 0;
+            right: -8px;
+            top: 10px;
+            width: 100px;
+            height: 35px;
+            -webkit-box-shadow: 0 0 3px rgba(0, 0, 0, .3);
+            box-shadow: 0 0 3px rgba(0, 0, 0, .3);
+            background-color: #dedede;
+            background-image: -webkit-linear-gradient(top, #f3b133 45%, #f7cd7d 100%);
+            background-image: -o-linear-gradient(top, #f3b133 45%, #f7cd7d 100%);
+            background-image: linear-gradient(to bottom, #f3b133 45%, #f7cd7d 100%);
+            background-repeat: repeat-x;
+        }
+
+        .ribbon:before,
+        .ribbon:after {
+            content: "";
+            border-top: 3px solid #9e9e9e;
+            border-left: 3px solid transparent;
+            border-right: 3px solid transparent;
+            position: absolute;
+            bottom: -3px
+        }
+
+        .ribbon:before {
+            left: 0
+        }
+
+        .ribbon:after {
+            right: 0
+        }
+        .hero-image {
+            border-radius: 6px;
+            margin: 10px;
+        }
+        .hero-title {
+            padding-top: 1.2rem;
+        }
+    }
+}

--- a/LMS/Dashboard/Resources/views/components/dashboard-hero.blade.php
+++ b/LMS/Dashboard/Resources/views/components/dashboard-hero.blade.php
@@ -1,0 +1,63 @@
+
+@if($type == 'mostRated')
+<div class="card">
+    <div class="hero-ribbon-wrapper">
+        <div class="ribbon">Gratuito</div>
+    </div>
+    <div class="card-body">
+        <div class="row">
+            <div class="col-md-4">
+                <img class="hero-image img-fluid" src="{{ $course->getFirstMediaUrl() }}"
+                     alt="{{ $course->name }} thumbnail">
+            </div>
+            <div class="col-md-8">
+                <h2 class="hero-title"> {{ $course->title }}</h2>
+                <p class="hero-description card-description"> {!! substr($course->description, 0, 450) !!}...</p>
+                <div  class="text-right">
+                    <form method="POST" action="{{ route('course-join', ['course' => $course]) }}">
+                        @csrf
+                        <span class="card-category mr-3"><i class="material-icons">people</i> {{ $course->students()->count() }}</span>
+                        <span class="card-category mr-3"><i class="material-icons">schedule</i> {{ gmdate('H:i', $course->duration) }}</span>
+                        <a href="{{ route('course-preview', ['slug' => $course->slug]) }}" class="btn btn-secondary" style="text-decoration: underline">Ver Grade Curricular</a>
+                        <button type="submit" class="btn btn-primary">Começar Agora</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endif
+@if($type == 'lastSeen')
+    <div class="card">
+        <div class="card-body">
+            <div class="row">
+                <div class="col-md-4">
+                    <img class="hero-image img-fluid" src="{{ $course->getFirstMediaUrl() }}"
+                         alt="{{ $course->name }} thumbnail">
+                </div>
+                <div class="col-md-8">
+                    <h2 class="hero-title"> {{ $course->title }}</h2>
+                    <p class="hero-description card-description"> {!! substr($course->description, 0, 450) !!}...</p>
+                    <div class="progress-container pt-1">
+                        <span class="progress-badge">Progresso do curso</span>
+                        <span class="progress-badge float-right">{{ $course->progress }}%</span>
+                        <div class="progress" style="height: 9px">
+                            <div class="progress-bar progress-bar-striped" role="progressbar" aria-valuenow="25"
+                                 style="width: {{ $course->progress }}%;">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="text-right">
+                        <span class="card-category mr-3"><i class="material-icons">people</i> {{ $course->students()->count() }}</span>
+                        <span class="card-category mr-3"><i class="material-icons">schedule</i> {{ gmdate('H:i', $course->duration) }}</span>
+                        <a href="{{ route('course-preview', ['slug' => $course->slug]) }}" class="btn btn-secondary" style="text-decoration: underline">Ver Grade Curricular</a>
+                        <a href="{{ route('course-lesson-redirect', ['slug' => $course->slug]) }}" class="btn btn-primary">
+                            <i class="material-icons mr-3">play_arrow</i>
+                            Continuar Assistindo
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endif

--- a/LMS/Dashboard/Resources/views/dashboard.blade.php
+++ b/LMS/Dashboard/Resources/views/dashboard.blade.php
@@ -1,0 +1,42 @@
+@extends('lms.templates.dashboard')
+@section('content')
+    <div class="container-fluid dashboard">
+        <x-dashboard-hero :hero="$hero" />
+        <div class="row">
+            @foreach($courses = \LMS\Courses\Models\Course::paginate() as $course)
+                <div class="col-12 col-sm-4 col-md-3">
+                    <a href="{{ route('course-preview', ['slug' => $course->slug]) }}" style="cursor: pointer;">
+                        <div class="card card-product">
+                            <div class="card-header card-header-image">
+                                <img class="img" src="{{ $course->getFirstMediaUrl() }}">
+                            </div>
+                            <div class="card-body">
+                                <h4 class="card-title" style="font-size: 1.1rem;">
+                                    {{ $course->title }}
+                                </h4>
+                                <div class="card-description" style="min-height: 92px">
+                                    {{ $course->subtitle }}
+                                </div>
+                            </div>
+                            <div class="card-footer">
+                                <div class="stats">
+                                    <p class="card-category">
+                                        <i class="material-icons"
+                                           style="top: 0;">shopping_cart</i>{{ $course->paid ? trans('courses::view.manage.form.paid.true') : trans('courses::view.manage.form.paid.false') }}
+                                        <i class="material-icons ml-2"
+                                           style="top: 0;">extension</i>{{ $course->level->name }}
+                                    </p>
+                                </div>
+                                <div class="stats">
+                                    <p class="card-category"><i
+                                            class="material-icons"
+                                            style="top: 0;">schedule</i> {{ gmdate('H:i', $course->duration) }}</p>
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+            @endforeach
+        </div>
+    </div>
+@endsection

--- a/LMS/Dashboard/View/Components/DashboardHero.php
+++ b/LMS/Dashboard/View/Components/DashboardHero.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace LMS\Dashboard\View\Components;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+use LMS\Courses\Models\Course;
+
+class DashboardHero extends Component
+{
+    private Course $course;
+    private string $type;
+
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(array $hero)
+    {
+        $this->course = $hero['course'];
+        $this->type = $hero['type'];
+    }
+
+    public function render(): View
+    {
+        return view('dashboard::components.dashboard-hero', [
+            'course' => $this->course,
+            'type' => $this->type
+        ]);
+    }
+}

--- a/resources/scss/admin.scss
+++ b/resources/scss/admin.scss
@@ -90,3 +90,4 @@
 @import "~material-icons/iconfont/material-icons";
 @import "~toastr/toastr";
 @import "~plyr";
+@import "../../LMS/Dashboard/Resources/scss/dashboard";

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use LMS\Billings\Http\Controllers\Subscriptions\ViewController as SubscriptionVi
 use LMS\Courses\Http\Controllers\CoursesController;
 use LMS\Courses\Http\Controllers\LevelController;
 use LMS\Courses\Http\Controllers\ViewController as CoursesViewController;
+use LMS\Dashboard\Http\Controllers\ViewController as DashboardViewController;
 use LMS\Landing\Http\Controllers\ViewController as LandingViewController;
 use LMS\Lessons\Http\Controllers\LessonsController;
 use LMS\Modules\Http\Controllers\ModulesController;
@@ -36,9 +37,7 @@ use LMS\User\Http\Controllers\ViewController as UserViewController;
 
 Route::get('/', [LandingViewController::class, 'viewLandingPage'])->name('landing');
 
-Route::get('/dashboard', function () {
-    return view('lms.dashboard');
-})->name('dashboard')->middleware('auth');
+Route::get('/dashboard', [DashboardViewController::class, 'viewDashboard'])->name('dashboard')->middleware('auth');
 
 Route::prefix('courses')
     ->middleware('auth')


### PR DESCRIPTION
Nesse PR eu subi uma feature "Hero" pra pagina inicial após feito o Login, que estava no estado abaixo inicialmente.
![image](https://user-images.githubusercontent.com/6912596/134750682-0579de20-35c7-4c48-9ab7-f41dfadcc1a9.png)

A ideia foi bem estruturada pela @vitoriazoche, de fazer duas possibilidades pra esse hero:

- Quando o usuário acaba de entrar na plataforma, jogar o curso gratuito mais acessado pra ele começar a entender o fluxo da plataforma.
![image](https://user-images.githubusercontent.com/6912596/134750870-5774fd88-bcf5-4026-a3eb-738076fb63e6.png)

- Quando o usuário já é registrado e assistiu alguma aula de algum curso, pegar a última aula assistida e colocar o curso pro usuário continuar assistindo.
![image](https://user-images.githubusercontent.com/6912596/134750907-e6521462-950d-4ea5-aab1-9413d3d984a0.png)

A estrutura desse dominio ficou desse jeito:
```
.
├── Domain.php
├── Http
│   └── Controllers
│       └── ViewController.php
├── Providers
│   └── DashboardServiceProvider.php
├── Repositories
│   └── DashboardRepository.php
├── Resources
│   ├── scss
│   │   └── dashboard.scss
│   └── views
│       ├── components
│       │   └── dashboard-hero.blade.php
│       └── dashboard.blade.php
└── View
    └── Components
        └── DashboardHero.php
```